### PR TITLE
An example of addition of a new custom field creation and retrieving it back from the database of com_content component.

### DIFF
--- a/administrator/components/com_content/models/forms/article.xml
+++ b/administrator/components/com_content/models/forms/article.xml
@@ -27,6 +27,11 @@
 		<field name="articletext" type="editor"
 			label="COM_CONTENT_FIELD_ARTICLETEXT_LABEL" description="COM_CONTENT_FIELD_ARTICLETEXT_DESC"
 			filter="JComponentHelper::filterText" buttons="true" />
+		
+		<field name="japaneseText" type="editor" class="inputbox" 
+			label="COM_CONTENT_FIELD_ARTICLETEXT_LABEL" description="COM_CONTENT_FIELD_ARTICLETEXT_DESC" 
+			filter="ContentHelper::filterText" buttons="true" 
+		/>
 
 		<field name="state" type="list" label="JSTATUS"
 			description="JFIELD_PUBLISHED_DESC" class="chzn-color-state"

--- a/administrator/components/com_content/views/article/tmpl/edit.php
+++ b/administrator/components/com_content/views/article/tmpl/edit.php
@@ -87,6 +87,10 @@ JFactory::getDocument()->addScriptDeclaration('
 				<fieldset class="adminform">
 					<?php echo $this->form->getInput('articletext'); ?>
 				</fieldset>
+				<div class="clr"></div>
+					<label>Article Text - Japanese Text</label>
+				<div class="clr"></div>
+					<?php echo $this->form->getInput('newtextbox'); ?>
 			</div>
 			<div class="span3">
 				<?php echo JLayoutHelper::render('joomla.edit.global', $this); ?>

--- a/administrator/components/com_content/views/article/tmpl/edit.php
+++ b/administrator/components/com_content/views/article/tmpl/edit.php
@@ -88,7 +88,7 @@ JFactory::getDocument()->addScriptDeclaration('
 					<?php echo $this->form->getInput('articletext'); ?>
 				</fieldset>
 				<div class="clr"></div>
-					<label>Article Text - Japanese Text</label>
+					<?php echo $this->form->getLabel('articletext'); ?>
 				<div class="clr"></div>
 					<?php echo $this->form->getInput('newtextbox'); ?>
 			</div>

--- a/components/com_content/models/article.php
+++ b/components/com_content/models/article.php
@@ -87,7 +87,7 @@ class ContentModelArticle extends JModelItem
 				$query = $db->getQuery(true)
 					->select(
 						$this->getState(
-							'item.select', 'a.id, a.asset_id, a.title, a.alias, a.introtext, a.fulltext, ' .
+							'item.select', 'a.id, a.asset_id, a.title, a.alias, a.introtext, a.fulltext,a.newtextbox, ' .
 							// If badcats is not null, this means that the article is inside an unpublished category
 							// In this case, the state is set to 0 to indicate Unpublished (even if the article state is Published)
 							'CASE WHEN badcats.id is null THEN a.state ELSE 0 END AS state, ' .

--- a/components/com_content/views/article/tmpl/default.php
+++ b/components/com_content/views/article/tmpl/default.php
@@ -111,6 +111,7 @@ JHtml::_('behavior.caption');
 	endif; ?>
 	<div itemprop="articleBody">
 		<?php echo $this->item->text; ?>
+		<?php echo $this->item->newtextbox; ?>
 	</div>
 
 	<?php if ($info == 1 || $info == 2) : ?>


### PR DESCRIPTION
Before making changes how the article edit view looks like:

![before](https://cloud.githubusercontent.com/assets/12000068/15984678/b7853052-2ff1-11e6-8a3a-62873621f238.png)

After making the changes it looks like this:

![after](https://cloud.githubusercontent.com/assets/12000068/15984679/bab7e800-2ff1-11e6-91a4-e0902508b152.png)

After Writing the content in first Editor and second editor.
First editor content: "Bob works hard"
Second editor content: "Bob is lazy"
The output in the frontend looks like:

![database](https://cloud.githubusercontent.com/assets/12000068/15984715/4d3b0fcc-2ff2-11e6-82cb-eabb754f0e44.png)
